### PR TITLE
Added Optional Auto Compile Feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.5.0] - 2015-07-08
+### Added
+- Optional auto compile feature.
+
 ## [2.0.1] - 2015-05-28
 ### Fixed
 - Fixed critical bug when compiling without options, which caused mangling and map generation not being considered by default.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ JSCompiler2 is a tool for [Brackets](https://github.com/adobe/brackets) that all
 
 Simply press the "Compress JavaScript" button on the sidebar, or go to `File > Compress JavaScript`, and your code will be compressed into a `{filename}.min.js` file.
 
+Optionally, you can toggle "Compress JavaScript on Save" by going to `File > Compress JavaScript on Save`, and your code will be compressed automatically. This options is off by default.
+
 ### The custom options file
 
 You can go to `File > Compress JavaScript: Options` to open your custom options. If you have no custom options yet, you will be asked to choose one of this types of custom options:

--- a/main.js
+++ b/main.js
@@ -58,7 +58,6 @@ define(function (require, exports, module) {
 
     // UglifyJS call
     function doUglify(inputs, output, options, directory) {
-        //bottomPanel.show();
 
         // Get current directory
         if (directory === undefined) {
@@ -201,7 +200,6 @@ define(function (require, exports, module) {
             if (err) {
                 if (err === 'NotFound') {
                     // Options file not found. Using project options?
-                    bottomPanel.show();
                     preferences = PreferencesManager.get('jscompiler');
                     if (preferences !== undefined) {
                         // Read project options file
@@ -225,7 +223,6 @@ define(function (require, exports, module) {
                 }
             } else {
                 // Read portable options file
-                //bottomPanel.show();
                 appendLog('Loading portable options');
                 options = JSON.parse(content);
                 compileWithOptions(options, directory);
@@ -387,7 +384,10 @@ define(function (require, exports, module) {
             title: 'Compress JavaScript',
             href: '#'
         })
-        .click(compileJS)
+        .click(function() {
+            bottomPanel.show();
+            compileJS();
+    })
         .appendTo($('#main-toolbar .buttons'))[0];
 
     // Add status icon

--- a/main.js
+++ b/main.js
@@ -412,7 +412,7 @@ define(function (require, exports, module) {
         compileJS();
     });
 
-    // Compile on save only if local .jscompiler.json file exists
+    // Compile on save
     $(DocumentManager).on("documentSaved", function (event, doc) {
         if (prefs.get("on-save")) {
             compileJS();

--- a/main.js
+++ b/main.js
@@ -1,350 +1,421 @@
 /*global brackets, define, $ */
 define(function (require, exports, module) {
-	'use strict';
+    'use strict';
 
-	var Commands           = brackets.getModule('command/Commands'),
-		CommandManager     = brackets.getModule('command/CommandManager'),
-		Menus              = brackets.getModule('command/Menus'),
-		DocumentManager    = brackets.getModule('document/DocumentManager'),
-		FileSystem         = brackets.getModule('filesystem/FileSystem'),
-		PreferencesManager = brackets.getModule('preferences/PreferencesManager'),
-		ProjectManager     = brackets.getModule('project/ProjectManager'),
-		ExtensionUtils     = brackets.getModule('utils/ExtensionUtils'),
-		WorkspaceManager   = brackets.getModule('view/WorkspaceManager'),
-		DefaultDialogs     = brackets.getModule('widgets/DefaultDialogs'),
-		Dialogs            = brackets.getModule('widgets/Dialogs'),
-		UglifyJS           = require('UglifyJS/uglifyjs'),
-		
-		menu = Menus.getMenu(Menus.AppMenuBar.FILE_MENU),
-		bottomPanel = null,
-		panelLog = null,
-		toolbarIcon = null,
-		pendingTasks = 0;
-	
-	window.MOZ_SourceMap   = require('./SourceMap/source-map');
+    var Commands           = brackets.getModule('command/Commands'),
+        CommandManager     = brackets.getModule('command/CommandManager'),
+        Menus              = brackets.getModule('command/Menus'),
+        DocumentManager    = brackets.getModule('document/DocumentManager'),
+        FileSystem         = brackets.getModule('filesystem/FileSystem'),
+        PreferencesManager = brackets.getModule('preferences/PreferencesManager'),
+        ProjectManager     = brackets.getModule('project/ProjectManager'),
+        ExtensionUtils     = brackets.getModule('utils/ExtensionUtils'),
+        WorkspaceManager   = brackets.getModule('view/WorkspaceManager'),
+        DefaultDialogs     = brackets.getModule('widgets/DefaultDialogs'),
+        Dialogs            = brackets.getModule('widgets/Dialogs'),
+        UglifyJS           = require('UglifyJS/uglifyjs'),
 
-	// Log
-	function log(s) {
-		window.console.log('[JSCompiler] ' + s);
-	}
+        menu = Menus.getMenu(Menus.AppMenuBar.FILE_MENU),
+        bottomPanel = null,
+        panelLog = null,
+        toolbarIcon = null,
+        statusIcon = null,
+        pendingTasks = 0,
+        prefs = PreferencesManager.getExtensionPrefs("jscompiler"),
+        compileAutoId = 'jscompiler.auto',
+        automaton;
 
-	function appendLog(s) {
-		panelLog.append('<br/>' + s);
-		panelLog.scrollTop(panelLog[0].scrollHeight);
-	}
-	
-	function taskDone() {
-		pendingTasks -= 1;
-		if (pendingTasks < 1) {
-			appendLog('Done!<br/>');
-			if (toolbarIcon.getAttribute('class') === 'active') {
-				toolbarIcon.setAttribute('class', 'success');
-			}
-			window.setTimeout(function () {toolbarIcon.removeAttribute('class'); }, 3000);
-		}
-	}
+    prefs.definePreference("on-save", "boolean", false);
 
-	// UglifyJS call
-	function doUglify(inputs, output, options, directory) {
-		bottomPanel.show();
-		
-		// Get current directory
-		if (directory === undefined) {
-			directory = DocumentManager.getCurrentDocument().file.parentPath;
-		}
-		var path = directory + output,
-		
-		// Start UglifyJS magic!
-			ast = null,
-			code = null,
-			compressor = UglifyJS.Compressor(),
-			source_map = UglifyJS.SourceMap(),
-			stream = UglifyJS.OutputStream({source_map: source_map}),
-			i = 0,
-			l = 0;
-		for (i = 0, l = inputs.length; i < l; i += 1) {
-			appendLog('Parsing file: ' + inputs[i].name);
-			ast = UglifyJS.parse(inputs[i].content, {filename: inputs[i].name, toplevel: ast});
-		}
-		appendLog('Compressing...');
-		ast.figure_out_scope();
-		ast.transform(compressor);
-		if (!options || options.mangle) {
-			appendLog('Mangling...');
-			ast.figure_out_scope();
-			ast.compute_char_frequency();
-			ast.mangle_names();
-		}
-		appendLog('Extracting...');
-		ast.print(stream);
-		code = stream.toString();
-		
-		// Append isolation code
-		if (options && options.isolate) {
-			appendLog('Isolating...');
-			code = '(function(window,undefined){' + code + '})(window);';
-		}
-		
-		appendLog('Exporting...');
-		// Save the map
-		if (!options || options.generateMap) {
-			code += '\n//# sourceMappingURL=' + output.split('/').pop() + '.map';
-			pendingTasks += 1;
-			FileSystem.getFileForPath(path + '.map').write(source_map.toString(), {blind: true}, function (err) {
-				if (err) {
-					appendLog('Error generating map at:<br/>' + path + '.map');
-					Dialogs.showModalDialog(DefaultDialogs.DIALOG_ID_ERROR, 'JS Compiler', 'Error on map genetarion:\n' + err);
-					toolbarIcon.setAttribute('class', 'error');
-				} else {
-					appendLog('Map successfully generated at:<br/>' + path + '.map');
-				}
-				taskDone();
-			});
-		}
-		
-		// Save the code
-		pendingTasks += 1;
-		FileSystem.getFileForPath(path).write(code, {blind: true}, function (err) {
-			if (err) {
-				appendLog('Error compiling code at:<br/>' + path);
-				Dialogs.showModalDialog(DefaultDialogs.DIALOG_ID_ERROR, 'JS Compiler', 'Error on compilation:\n' + err);
-				toolbarIcon.setAttribute('class', 'error');
-			} else {
-				appendLog('File successfully compiled at:<br/>' + path);
-			}
-			taskDone();
-		});
-	}
-	
-	function getContentsFrom(options, directory, contents, counter) {
-		if (counter < options.inputs.length) {
-			// There is content pending to get. Read it!
-			appendLog('Reading ' + options.inputs[counter] + '...');
-			
-			FileSystem.getFileForPath(directory + options.inputs[counter]).read({}, function (err, content) {
-				if (err) {
-					appendLog('Error on reading ' + options.inputs[counter] + ': ' + err + '<br/>' + options.output + ' compilation cancelled.<br/>');
-					toolbarIcon.setAttribute('class', 'warning');
-				} else {
-					// Read content
-					contents.push({name: options.inputs[counter], content: content});
-					getContentsFrom(options, directory, contents, counter + 1);
-				}
-			});
-		} else {
-			// Contents where collected
-			if (contents.length > 0) {
-				// Finally compile the code
-				if (options.precompile) {
-					appendLog('Precompiling code into: precompiled.js');
-					var content = '',
-						i = 0,
-						l = 0;
-					for (i = 0, l = contents.length; i < l; i += 1) {
-						content += contents[i].content + '\n';
-					}
-					doUglify([{name: 'precompiled.js', content: content}], options.output, options, directory);
-				} else {
-					doUglify(contents, options.output, options, directory);
-				}
-			} else {
-				appendLog('Something went wrong.<br/>Done!');
-			}
-		}
-	}
-	
-	function compileWithOptions(options, directory) {
-		var i = 0,
-			l = 0;
-		if (options.outputs) {
-			// Compile each output in options
-			l = options.outputs.length;
-			appendLog('Found ' + l + ' outputs');
-			for (i = 0; i < l; i += 1) {
-				appendLog('Generating ' + options.outputs[i].output);
-				getContentsFrom(options.outputs[i], directory, [], 0);
-			}
-		} else {
-			// Compile with old single output option format
-			appendLog('Generating ' + options.output);
-			getContentsFrom(options, directory, [], 0);
-		}
-	}
-	
-	function compileJS() {
-		log('Executing Command Compile');
-		pendingTasks = 0;
-		toolbarIcon.setAttribute('class', 'active');
-		
-		// Search for options file
-		var currentFile = DocumentManager.getCurrentDocument().file,
-			directory = currentFile.parentPath,
-			options,
-			preferences = null;
-		FileSystem.getFileForPath(directory + '.jscompiler.json').read({}, function (err, content) {
-			if (err) {
-				if (err === 'NotFound') {
-					// Options file not found. Using project options?
-					bottomPanel.show();
-					preferences = PreferencesManager.get('jscompiler');
-					if (preferences !== undefined) {
-						// Read project options file
-						appendLog('Loading project options');
-						compileWithOptions(preferences, ProjectManager.getProjectRoot().fullPath);
-					} else {
-						// Options not found. Try to compile current file
-						appendLog('No options file. Compiling current script');
-						var ext = currentFile.name.split('.').pop();
-						if (ext === 'js') {
-							doUglify([{name: currentFile.name, content: DocumentManager.getCurrentDocument().getText()}], currentFile.name.replace(/\.js$/, '.min.js'), undefined, directory);
-						} else {
-							// Current file is not JavaScript. Warn!
-							appendLog('Current document is not JavaScript');
-						}
-					}
-				} else {
-					Dialogs.showModalDialog(DefaultDialogs.DIALOG_ID_ERROR, 'JS Compiler', 'Error on reading options:\n' + err);
-					toolbarIcon.setAttribute('class', 'error');
-				}
-			} else {
-				// Read portable options file
-				bottomPanel.show();
-				appendLog('Loading portable options');
-				options = JSON.parse(content);
-				compileWithOptions(options, directory);
-			}
-		});
-	}
-	
-	function generateOptions() {
-		// Read the template
-		ExtensionUtils.loadFile(module, 'templates/.jscompiler.json').then(function (result) {
-			// Get directory and file name for project options
-			var code = null,
-				jsonCode = null,
-				file = DocumentManager.getCurrentDocument().file,
-				directory = file.parentPath,
-				directories = directory.split('/'),
-				dirname = directories.pop(),
-				filename = file.name.replace(/\.js$/, ''),
-				i = 0,
-				j = 0,
-				l = 0,
-				jl = 0;
-			window.console.log(directory);
-			if (filename === file.name) {
-				filename = 'script';
-			}
-			dirname = directories.pop();
-			code = result.replace(/%DIRECTORY%/g, dirname).replace(/%FILENAME%/g, filename);
-			
-			// Ask the user which class of options file wants to use
-			Dialogs.showModalDialog(DefaultDialogs.DIALOG_ID_INFO, 'Options file not found', 'Select the type of options file you want to use for this project:', [{className: Dialogs.DIALOG_BTN_CLASS_LEFT, id: Dialogs.DIALOG_BTN_CANCEL, text: 'Cancel'}, {className: Dialogs.DIALOG_BTN_CLASS_PRIMARY, id: 'project', text: 'Project'}, {className: Dialogs.DIALOG_BTN_CLASS_NORMAL, id: 'portable', text: 'Portable'}]).done(function (id) {
-				window.console.log('ID: ' + id);
-				if (id === 'project') {
-					// Create options in project file
-					jsonCode = JSON.parse(code);
-					directory = ProjectManager.makeProjectRelativeIfPossible(directory);
-					for (i = 0, l = jsonCode.outputs.length; i < l; i += 1) {
-						// Assign relative path to each input and output
-						for (j = 0, jl = jsonCode.outputs[i].inputs.length; j < jl; j += 1) {
-							jsonCode.outputs[i].inputs[j] = directory + jsonCode.outputs[i].inputs[j];
-						}
-						jsonCode.outputs[i].output = directory + jsonCode.outputs[i].output;
-					}
-					PreferencesManager.set('jscompiler', jsonCode, {location: {scope: 'project'}});
-					// Open project options file
-					window.setTimeout(function () {CommandManager.execute(Commands.CMD_OPEN, {fullPath: ProjectManager.getProjectRoot().fullPath + '.brackets.json'}); }, 200);
-				} else if (id === 'portable') {
-					// Create portable options file
-					FileSystem.getFileForPath(directory + '.jscompiler.json').write(code, {blind: true}, function (err) {
-						if (err) {
-							Dialogs.showModalDialog(DefaultDialogs.DIALOG_ID_ERROR, 'JS Compiler', 'Error on creating options:\n' + err);
-						} else {
-							// Open options file
-							CommandManager.execute(Commands.CMD_OPEN, {fullPath: directory + '.jscompiler.json'});
-						}
-					});
-				}
-			});
-		});
-	}
-	
-	function openOptions() {
-		var directory = DocumentManager.getCurrentDocument().file.parentPath,
-			path = directory + '.jscompiler.json',
-			preferences = null;
-		
-		// Reading the options file content
-		FileSystem.getFileForPath(path).read({}, function (err, content) {
-			if (err) {
-				if (err === 'NotFound') {
-					// Options file not found. Using project options?
-					preferences = PreferencesManager.get('jscompiler');
-					if (preferences !== undefined) {
-						// Open project options file
-						CommandManager.execute(Commands.CMD_OPEN, {fullPath: ProjectManager.getProjectRoot().fullPath + '.brackets.json'});
-					} else {
-						// Options not found. Generate
-						log('Options file not found. Creating!');
-						generateOptions();
-					}
-				} else {
-					Dialogs.showModalDialog(DefaultDialogs.DIALOG_ID_ERROR, 'JS Compiler', 'Error on reading options:\n' + err);
-				}
-			} else {
-				// Open portable options file
-				CommandManager.execute(Commands.CMD_OPEN, {fullPath: path});
-			}
-		});
-	}
-	
-	function openTemplate() {
-		var path = ExtensionUtils.getModulePath(module, 'templates/.jscompiler.json');
-		
-		// Reading the options template... Just to be sure no one has deleted it accidentally...
-		FileSystem.getFileForPath(path).read({}, function (err, content) {
-			if (err) {
-				Dialogs.showModalDialog(DefaultDialogs.DIALOG_ID_ERROR, 'JS Compiler', 'Error on reading template:\n' + err);
-			} else {
-				// Open options template
-				CommandManager.execute(Commands.CMD_OPEN, {fullPath: path});
-			}
-		});
-	}
-	
-	function closePanel() {
-		bottomPanel.hide();
-	}
-	
-	// Add file menu option
-	menu.addMenuDivider();
-	
-	// Register commands
-	CommandManager.register('Compress JavaScript', 'jscompiler.compile', compileJS);
-	menu.addMenuItem('jscompiler.compile');
-	
-	CommandManager.register('Compress JavaScript: Options', 'jscompiler.options', openOptions);
-	menu.addMenuItem('jscompiler.options');
-	
-	CommandManager.register('Compress JavaScript: Options template', 'jscompiler.template', openTemplate);
-	menu.addMenuItem('jscompiler.template');
-	
-	// Start bottom panel
-	bottomPanel = WorkspaceManager.createBottomPanel('jscompiler.panel', $('<div id="jscompiler-panel" class="bottom-panel vert-resizable top-resizer" style="box-sizing: border-box; height: 200px; display: block;"><div class="toolbar simple-toolbar-layout"><div class="title">JSCompiler</div> <a href="#" class="close">×</a></div><div id="log" class="table-container resizable-content" style="height: 170px"></div></div></div>'));
-	panelLog = bottomPanel.$panel.find('#log');
-	bottomPanel.$panel.find('.close').on('click', closePanel);
-	
-	// Load css
-	ExtensionUtils.loadStyleSheet(module, 'styles/main.css');
-	
-	// Add toolbar icon
-	toolbarIcon = $('<a>')
-		.attr({
-			id: 'toolbar-jscompiler',
-			title: 'Compress JavaScript',
-			href: '#'
-		})
-		.click(compileJS)
-		.appendTo($('#main-toolbar .buttons'))[0];
+    window.MOZ_SourceMap   = require('./SourceMap/source-map');
+
+    // Log
+    function log(s) {
+        window.console.log('[JSCompiler] ' + s);
+    }
+
+    function appendLog(s) {
+        panelLog.append('<br/>' + s);
+        panelLog.scrollTop(panelLog[0].scrollHeight);
+    }
+
+    function taskDone() {
+        pendingTasks -= 1;
+        if (pendingTasks < 1) {
+            appendLog('Done!<br/>');
+            if (toolbarIcon.getAttribute('class') === 'active') {
+                toolbarIcon.setAttribute('class', 'success');
+            }
+            if (statusIcon.getAttribute('class') === 'active') {
+                statusIcon.setAttribute('class', 'success');
+            }
+            window.setTimeout(function () {
+                toolbarIcon.removeAttribute('class');
+                statusIcon.removeAttribute('class');
+            }, 3000);
+        }
+    }
+
+    // UglifyJS call
+    function doUglify(inputs, output, options, directory) {
+        //bottomPanel.show();
+
+        // Get current directory
+        if (directory === undefined) {
+            directory = DocumentManager.getCurrentDocument().file.parentPath;
+        }
+        var path = directory + output,
+
+        // Start UglifyJS magic!
+            ast = null,
+            code = null,
+            compressor = UglifyJS.Compressor(),
+            source_map = UglifyJS.SourceMap(),
+            stream = UglifyJS.OutputStream({source_map: source_map}),
+            i = 0,
+            l = 0;
+        for (i = 0, l = inputs.length; i < l; i += 1) {
+            appendLog('Parsing file: ' + inputs[i].name);
+            ast = UglifyJS.parse(inputs[i].content, {filename: inputs[i].name, toplevel: ast});
+        }
+        appendLog('Compressing...');
+        ast.figure_out_scope();
+        ast.transform(compressor);
+        if (!options || options.mangle) {
+            appendLog('Mangling...');
+            ast.figure_out_scope();
+            ast.compute_char_frequency();
+            ast.mangle_names();
+        }
+        appendLog('Extracting...');
+        ast.print(stream);
+        code = stream.toString();
+
+        // Append isolation code
+        if (options && options.isolate) {
+            appendLog('Isolating...');
+            code = '(function(window,undefined){' + code + '})(window);';
+        }
+
+        appendLog('Exporting...');
+        // Save the map
+        if (!options || options.generateMap) {
+            code += '\n//# sourceMappingURL=' + output.split('/').pop() + '.map';
+            pendingTasks += 1;
+            FileSystem.getFileForPath(path + '.map').write(source_map.toString(), {blind: true}, function (err) {
+                if (err) {
+                    appendLog('Error generating map at:<br/>' + path + '.map');
+                    Dialogs.showModalDialog(DefaultDialogs.DIALOG_ID_ERROR, 'JS Compiler', 'Error on map genetarion:\n' + err);
+                    toolbarIcon.setAttribute('class', 'error');
+                    statusIcon.setAttribute('class', 'error');
+                } else {
+                    appendLog('Map successfully generated at:<br/>' + path + '.map');
+                }
+                taskDone();
+            });
+        }
+
+        // Save the code
+        pendingTasks += 1;
+        FileSystem.getFileForPath(path).write(code, {blind: true}, function (err) {
+            if (err) {
+                appendLog('Error compiling code at:<br/>' + path);
+                Dialogs.showModalDialog(DefaultDialogs.DIALOG_ID_ERROR, 'JS Compiler', 'Error on compilation:\n' + err);
+                toolbarIcon.setAttribute('class', 'error');
+                statusIcon.setAttribute('class', 'error');
+            } else {
+                appendLog('File successfully compiled at:<br/>' + path);
+            }
+            taskDone();
+        });
+    }
+
+    function getContentsFrom(options, directory, contents, counter) {
+        if (counter < options.inputs.length) {
+            // There is content pending to get. Read it!
+            appendLog('Reading ' + options.inputs[counter] + '...');
+
+            FileSystem.getFileForPath(directory + options.inputs[counter]).read({}, function (err, content) {
+                if (err) {
+                    appendLog('Error on reading ' + options.inputs[counter] + ': ' + err + '<br/>' + options.output + ' compilation cancelled.<br/>');
+                    toolbarIcon.setAttribute('class', 'warning');
+                    statusIcon.setAttribute('class', 'warning');
+                } else {
+                    // Read content
+                    contents.push({name: options.inputs[counter], content: content});
+                    getContentsFrom(options, directory, contents, counter + 1);
+                }
+            });
+        } else {
+            // Contents where collected
+            if (contents.length > 0) {
+                // Finally compile the code
+                if (options.precompile) {
+                    appendLog('Precompiling code into: precompiled.js');
+                    var content = '',
+                        i = 0,
+                        l = 0;
+                    for (i = 0, l = contents.length; i < l; i += 1) {
+                        content += contents[i].content + '\n';
+                    }
+                    doUglify([{name: 'precompiled.js', content: content}], options.output, options, directory);
+                } else {
+                    doUglify(contents, options.output, options, directory);
+                }
+            } else {
+                appendLog('Something went wrong.<br/>Done!');
+            }
+        }
+    }
+
+    function compileWithOptions(options, directory) {
+        var i = 0,
+            l = 0;
+        if (options.outputs) {
+            // Compile each output in options
+            l = options.outputs.length;
+            appendLog('Found ' + l + ' outputs');
+            for (i = 0; i < l; i += 1) {
+                appendLog('Generating ' + options.outputs[i].output);
+                getContentsFrom(options.outputs[i], directory, [], 0);
+            }
+        } else {
+            // Compile with old single output option format
+            appendLog('Generating ' + options.output);
+            getContentsFrom(options, directory, [], 0);
+        }
+    }
+
+    function compileJS() {
+        log('Executing Command Compile');
+        pendingTasks = 0;
+        toolbarIcon.setAttribute('class', 'active');
+        statusIcon.setAttribute('class', 'active');
+
+        // Search for options file
+        var currentFile = DocumentManager.getCurrentDocument().file,
+            directory = currentFile.parentPath,
+            options,
+            preferences = null;
+        FileSystem.getFileForPath(directory + '.jscompiler.json').read({}, function (err, content) {
+            if (err) {
+                if (err === 'NotFound') {
+                    // Options file not found. Using project options?
+                    bottomPanel.show();
+                    preferences = PreferencesManager.get('jscompiler');
+                    if (preferences !== undefined) {
+                        // Read project options file
+                        appendLog('Loading project options');
+                        compileWithOptions(preferences, ProjectManager.getProjectRoot().fullPath);
+                    } else {
+                        // Options not found. Try to compile current file
+                        appendLog('No options file. Compiling current script');
+                        var ext = currentFile.name.split('.').pop();
+                        if (ext === 'js') {
+                            doUglify([{name: currentFile.name, content: DocumentManager.getCurrentDocument().getText()}], currentFile.name.replace(/\.js$/, '.min.js'), undefined, directory);
+                        } else {
+                            // Current file is not JavaScript. Warn!
+                            appendLog('Current document is not JavaScript');
+                        }
+                    }
+                } else {
+                    Dialogs.showModalDialog(DefaultDialogs.DIALOG_ID_ERROR, 'JS Compiler', 'Error on reading options:\n' + err);
+                    toolbarIcon.setAttribute('class', 'error');
+                    statusIcon.setAttribute('class', 'error');
+                }
+            } else {
+                // Read portable options file
+                //bottomPanel.show();
+                appendLog('Loading portable options');
+                options = JSON.parse(content);
+                compileWithOptions(options, directory);
+            }
+        });
+    }
+
+    function generateOptions() {
+        // Read the template
+        ExtensionUtils.loadFile(module, 'templates/.jscompiler.json').then(function (result) {
+            // Get directory and file name for project options
+            var code = null,
+                jsonCode = null,
+                file = DocumentManager.getCurrentDocument().file,
+                directory = file.parentPath,
+                directories = directory.split('/'),
+                dirname = directories.pop(),
+                filename = file.name.replace(/\.js$/, ''),
+                i = 0,
+                j = 0,
+                l = 0,
+                jl = 0;
+            window.console.log(directory);
+            if (filename === file.name) {
+                filename = 'script';
+            }
+            dirname = directories.pop();
+            code = result.replace(/%DIRECTORY%/g, dirname).replace(/%FILENAME%/g, filename);
+
+            // Ask the user which class of options file wants to use
+            Dialogs.showModalDialog(DefaultDialogs.DIALOG_ID_INFO, 'Options file not found', 'Select the type of options file you want to use for this project:', [{className: Dialogs.DIALOG_BTN_CLASS_LEFT, id: Dialogs.DIALOG_BTN_CANCEL, text: 'Cancel'}, {className: Dialogs.DIALOG_BTN_CLASS_PRIMARY, id: 'project', text: 'Project'}, {className: Dialogs.DIALOG_BTN_CLASS_NORMAL, id: 'portable', text: 'Portable'}]).done(function (id) {
+                window.console.log('ID: ' + id);
+                if (id === 'project') {
+                    // Create options in project file
+                    jsonCode = JSON.parse(code);
+                    directory = ProjectManager.makeProjectRelativeIfPossible(directory);
+                    for (i = 0, l = jsonCode.outputs.length; i < l; i += 1) {
+                        // Assign relative path to each input and output
+                        for (j = 0, jl = jsonCode.outputs[i].inputs.length; j < jl; j += 1) {
+                            jsonCode.outputs[i].inputs[j] = directory + jsonCode.outputs[i].inputs[j];
+                        }
+                        jsonCode.outputs[i].output = directory + jsonCode.outputs[i].output;
+                    }
+                    PreferencesManager.set('jscompiler', jsonCode, {location: {scope: 'project'}});
+                    // Open project options file
+                    window.setTimeout(function () {CommandManager.execute(Commands.CMD_OPEN, {fullPath: ProjectManager.getProjectRoot().fullPath + '.brackets.json'}); }, 200);
+                } else if (id === 'portable') {
+                    // Create portable options file
+                    FileSystem.getFileForPath(directory + '.jscompiler.json').write(code, {blind: true}, function (err) {
+                        if (err) {
+                            Dialogs.showModalDialog(DefaultDialogs.DIALOG_ID_ERROR, 'JS Compiler', 'Error on creating options:\n' + err);
+                        } else {
+                            // Open options file
+                            CommandManager.execute(Commands.CMD_OPEN, {fullPath: directory + '.jscompiler.json'});
+                        }
+                    });
+                }
+            });
+        });
+    }
+
+    function openOptions() {
+        var directory = DocumentManager.getCurrentDocument().file.parentPath,
+            path = directory + '.jscompiler.json',
+            preferences = null;
+
+        // Reading the options file content
+        FileSystem.getFileForPath(path).read({}, function (err, content) {
+            if (err) {
+                if (err === 'NotFound') {
+                    // Options file not found. Using project options?
+                    preferences = PreferencesManager.get('jscompiler');
+                    if (preferences !== undefined) {
+                        // Open project options file
+                        CommandManager.execute(Commands.CMD_OPEN, {fullPath: ProjectManager.getProjectRoot().fullPath + '.brackets.json'});
+                    } else {
+                        // Options not found. Generate
+                        log('Options file not found. Creating!');
+                        generateOptions();
+                    }
+                } else {
+                    Dialogs.showModalDialog(DefaultDialogs.DIALOG_ID_ERROR, 'JS Compiler', 'Error on reading options:\n' + err);
+                }
+            } else {
+                // Open portable options file
+                CommandManager.execute(Commands.CMD_OPEN, {fullPath: path});
+            }
+        });
+    }
+
+    function openTemplate() {
+        var path = ExtensionUtils.getModulePath(module, 'templates/.jscompiler.json');
+
+        // Reading the options template... Just to be sure no one has deleted it accidentally...
+        FileSystem.getFileForPath(path).read({}, function (err, content) {
+            if (err) {
+                Dialogs.showModalDialog(DefaultDialogs.DIALOG_ID_ERROR, 'JS Compiler', 'Error on reading template:\n' + err);
+            } else {
+                // Open options template
+                CommandManager.execute(Commands.CMD_OPEN, {fullPath: path});
+            }
+        });
+    }
+
+    function closePanel() {
+        bottomPanel.hide();
+    }
+
+    function showHideIcons() {
+        if (prefs.get("on-save")) {
+            $('#status-jscompiler').show();
+            $('#toolbar-jscompiler').hide();
+        } else {
+            $('#status-jscompiler').hide();
+            $('#toolbar-jscompiler').show();
+        }
+    }
+
+    // Add file menu option
+    menu.addMenuDivider();
+
+    // Register commands
+    CommandManager.register('Compress JavaScript', 'jscompiler.compile', compileJS);
+    menu.addMenuItem('jscompiler.compile');
+
+    //compile on save option
+    CommandManager.register('Compress JavaScript on Save', compileAutoId, function () {
+        this.setChecked(!this.getChecked());
+    });
+    automaton = CommandManager.get(compileAutoId);
+    $(automaton).on('checkedStateChange', function () {
+        prefs.set("on-save", automaton.getChecked());
+        showHideIcons();
+    });
+
+
+    menu.addMenuItem(automaton);
+
+    CommandManager.register('Compress JavaScript: Options', 'jscompiler.options', openOptions);
+    menu.addMenuItem('jscompiler.options');
+
+    CommandManager.register('Compress JavaScript: Options template', 'jscompiler.template', openTemplate);
+    menu.addMenuItem('jscompiler.template');
+
+    automaton.setChecked(prefs.get("on-save"));
+
+    // Start bottom panel
+    bottomPanel = WorkspaceManager.createBottomPanel('jscompiler.panel', $('<div id="jscompiler-panel" class="bottom-panel vert-resizable top-resizer" style="box-sizing: border-box; height: 200px; display: block;"><div class="toolbar simple-toolbar-layout"><div class="title">JSCompiler</div><div class="compile">Compile</div> <a href="#" class="close">×</a></div><div id="log" class="table-container resizable-content" style="height: 170px"></div></div></div>'));
+    panelLog = bottomPanel.$panel.find('#log');
+    bottomPanel.$panel.find('.close').on('click', closePanel);
+
+    // Load css
+    ExtensionUtils.loadStyleSheet(module, 'styles/main.css');
+
+    // Add toolbar icon
+    toolbarIcon = $('<a>')
+        .attr({
+            id: 'toolbar-jscompiler',
+            title: 'Compress JavaScript',
+            href: '#'
+        })
+        .click(compileJS)
+        .appendTo($('#main-toolbar .buttons'))[0];
+
+    // Add status icon
+    statusIcon = $('<div>&nbsp;</div>')
+        .attr({
+            id: 'status-jscompiler',
+            title: 'JavaScript Compiler Log',
+            href: '#'
+        })
+        .click(function () {
+            if ($('#jscompiler-panel').css('display') === 'none') {
+                bottomPanel.show();
+            } else {
+                bottomPanel.hide();
+            }
+        })
+        .insertAfter($('#status-indicators #status-indent'))[0];
+
+    showHideIcons();
+
+    $('#jscompiler-panel .compile').click(function () {
+        compileJS();
+    });
+
+    // Compile on save only if local .jscompiler.json file exists
+    $(DocumentManager).on("documentSaved", function (event, doc) {
+        if (prefs.get("on-save")) {
+            compileJS();
+        }
+    });
 });

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "author": "Karl Tayfer",
     "contributors": [
         "Karl Tayfer (https://github.com/daPhyre)",
+        "mrmckeb (https://github.com/mrmckeb)",
         "Henry LaVoo (https://github.com/henrylavoo)"
     ],
     "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,16 @@
 {
-	"name": "ktayfer.jscompiler",
-	"title": "JSCompiler2",
-	"description": "Compress your JavaScript code from multiple files into one minified file (Powered by UglifyJS2).",
-	"homepage": "https://github.com/daPhyre/brackets-jscompiler",
-	"version": "2.0.1",
-	"author": "Karl Tayfer",
-	"license": "MIT",
-	"engines": {
-		"brackets": ">=1.0.0"
-	}
+    "name": "ktayfer.jscompiler",
+    "title": "JSCompiler2",
+    "description": "Compress your JavaScript code from multiple files into one minified file (Powered by UglifyJS2).",
+    "homepage": "https://github.com/daPhyre/brackets-jscompiler",
+    "version": "2.5.0",
+    "author": "Karl Tayfer",
+    "contributors": [
+        "Karl Tayfer (https://github.com/daPhyre)",
+        "Henry LaVoo (https://github.com/henrylavoo)"
+    ],
+    "license": "MIT",
+    "engines": {
+        "brackets": ">=1.0.0"
+    }
 }

--- a/styles/main.css
+++ b/styles/main.css
@@ -1,20 +1,57 @@
 #toolbar-jscompiler {
-	background-image: url(images/jscompiler.svg);
-	height: 24px;
-	width: 24px;
+    background-image: url(images/jscompiler.svg);
+    height: 24px;
+    width: 24px;
 }
 #toolbar-jscompiler.success {
-	background-position: 0 -24px;
+    background-position: 0 -24px;
 }
 #toolbar-jscompiler.active {
-	background-position: 0 -48px;
+    background-position: 0 -48px;
 }
 #toolbar-jscompiler.warning {
-	background-position: 0 -72px;
+    background-position: 0 -72px;
 }
 #toolbar-jscompiler.error {
-	background-position: 0 -96px;
+    background-position: 0 -96px;
 }
 #toolbar-jscompiler.disabled {
    opacity: 0.4;
+}
+#status-jscompiler {
+    background-color: transparent;
+    background-image: url(images/jscompiler.svg);
+    background-repeat: no-repeat;
+    cursor: pointer;
+    width: 5px;
+}
+
+#status-jscompiler.success {
+    background-position: 0 -24px;
+}
+#status-jscompiler.active {
+    background-position: 0 -48px;
+}
+#status-jscompiler.warning {
+    background-position: 0 -72px;
+}
+#status-jscompiler.error {
+    background-position: 0 -96px;
+}
+#status-jscompiler.disabled {
+    opacity: 0.4;
+}
+#jscompiler-panel .compile {
+    margin-left: 10px;
+    padding: 0 5px;
+    border-radius: 3px;
+    background-color: #3C3F41;
+    text-transform: uppercase;
+    font-size: 12px;
+    color: #ddd;
+    cursor: pointer;
+}
+#jscompiler-panel .compile:hover {
+    background-color: #47484B;
+    color: #fff;
 }


### PR DESCRIPTION
Auto compile feature is off by default and can be toggled in the File menu.

When the auto compile feature is enabled the compiler icon moves from the right sidebar down to the status bar next to the Brackets lint status icon. Clicking the JSCompiler status icon will toggle the compiler log window. Inside the log window is a new button the manually compile.

When the auto compile feature is off the plugin will function exactly as it did before.